### PR TITLE
Allow setting a connection name.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+# 1.1.0
+
+- Allow setting a connection name ([PR](https://github.com/KardinalAI/gorabbit/pull/8))

--- a/client.go
+++ b/client.go
@@ -156,6 +156,7 @@ func newClientFromOptions(options *ClientOptions) MQTTClient {
 	client.connectionManager = newConnectionManager(
 		client.ctx,
 		dialURL,
+		options.ConnectionName,
 		options.KeepAlive,
 		options.RetryDelay,
 		options.MaxRetry,

--- a/client_options.go
+++ b/client_options.go
@@ -26,6 +26,9 @@ type ClientOptions struct {
 	// UseTLS defines whether we use amqp or amqps protocol.
 	UseTLS bool
 
+	// ConnectionName is the client connection name passed on to the RabbitMQ server.
+	ConnectionName string
+
 	// KeepAlive will determine whether the re-connection and retry mechanisms should be triggered.
 	KeepAlive bool
 
@@ -138,6 +141,13 @@ func (c *ClientOptions) SetVhost(vhost string) *ClientOptions {
 // SetUseTLS will assign the UseTLS status.
 func (c *ClientOptions) SetUseTLS(use bool) *ClientOptions {
 	c.UseTLS = use
+
+	return c
+}
+
+// SetConnectionName will assign the ConnectionName.
+func (c *ClientOptions) SetConnectionName(connectionName string) *ClientOptions {
+	c.ConnectionName = connectionName
 
 	return c
 }

--- a/connection.go
+++ b/connection.go
@@ -150,8 +150,8 @@ func (a *amqpConnection) open() error {
 
 	// We request a connection from the RabbitMQ server.
 	conn, err := amqp.DialConfig(a.uri, amqp.Config{
-		Heartbeat:  10 * time.Second,
-		Locale:     "en_US",
+		Heartbeat:  defaultHeartbeat,
+		Locale:     defaultLocale,
 		Properties: props,
 	})
 	if err != nil {

--- a/connection_manager.go
+++ b/connection_manager.go
@@ -18,6 +18,7 @@ type connectionManager struct {
 func newConnectionManager(
 	ctx context.Context,
 	uri string,
+	connectionName string,
 	keepAlive bool,
 	retryDelay time.Duration,
 	maxRetry uint,
@@ -26,8 +27,8 @@ func newConnectionManager(
 	logger logger,
 ) *connectionManager {
 	c := &connectionManager{
-		consumerConnection:  newConsumerConnection(ctx, uri, keepAlive, retryDelay, logger),
-		publisherConnection: newPublishingConnection(ctx, uri, keepAlive, retryDelay, maxRetry, publishingCacheSize, publishingCacheTTL, logger),
+		consumerConnection:  newConsumerConnection(ctx, uri, connectionName, keepAlive, retryDelay, logger),
+		publisherConnection: newPublishingConnection(ctx, uri, connectionName, keepAlive, retryDelay, maxRetry, publishingCacheSize, publishingCacheTTL, logger),
 	}
 
 	return c

--- a/constants.go
+++ b/constants.go
@@ -30,6 +30,12 @@ const (
 	defaultMode                = Release
 )
 
+// Default values for the amqp Config.
+const (
+	defaultHeartbeat = 10 * time.Second
+	defaultLocale    = "en_US"
+)
+
 const (
 	xDeathCountHeader = "x-death-count"
 )


### PR DESCRIPTION
This can be helpful to identify specific connections in RabbitMQ, for debugging or tracing purposes.

I've matched the default values in `amqp.Config` (which are annoyingly not exposed in the lib itself), so behavior should be completely identical if this parameter is not set.