### PR TITLE
Minor connection name fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.1.1
+
+- Minor fix for correct usage of the `ConnectionName` parameter, and the possibility to declare it via environment variables ([PR](https://github.com/KardinalAI/gorabbit/pull/18)).
+
 # 1.1.0
 
 - Allow setting a connection name ([PR](https://github.com/KardinalAI/gorabbit/pull/8))

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ parameter.
 | Password            | The plain authentication password                             | guest         |
 | Vhost               | The specific vhost to use when connection to CloudAMQP        |               |
 | UseTLS              | The flag that activates the use of TLS (amqps)                | false         |
+| ConnectionName      | The desired connection name                                   | Gorabbit      |
 | KeepAlive           | The flag that activates retry and re-connect mechanisms       | true          |
 | RetryDelay          | The delay between each retry and re-connection                | 3 seconds     |
 | MaxRetry            | The max number of message retry if it failed to process       | 5             |
@@ -142,6 +143,7 @@ Here are the following supported environment variables:
 * `RABBITMQ_PASSWORD`: Defines the password,
 * `RABBITMQ_VHOST`: Defines the vhost,
 * `RABBITMQ_USE_TLS`: Defines whether to use TLS or no.
+* `RABBITMQ_CONNECTION_NAME`: Defines the desired connection name.
 
 **Note that environment variables are all optional, so missing keys will be replaced by their corresponding default.**
 

--- a/client_options.go
+++ b/client_options.go
@@ -109,6 +109,7 @@ func NewClientOptionsFromEnv() *ClientOptions {
 	}
 
 	defaultOpts.UseTLS = fromEnv.UseTLS
+	defaultOpts.ConnectionName = fromEnv.ConnectionName
 
 	return defaultOpts
 }

--- a/connection.go
+++ b/connection.go
@@ -2,9 +2,11 @@ package gorabbit
 
 import (
 	"context"
+	"fmt"
 	"net/url"
 	"time"
 
+	"github.com/google/uuid"
 	amqp "github.com/rabbitmq/amqp091-go"
 )
 
@@ -70,6 +72,8 @@ func newConsumerConnection(
 	logger logger,
 	marshaller Marshaller,
 ) *amqpConnection {
+	connectionName = fmt.Sprintf("%s-consumer-%s", connectionName, uuid.NewString())
+
 	return newConnection(ctx, uri, connectionName, keepAlive, retryDelay, logger, connectionTypeConsumer, marshaller)
 }
 
@@ -96,6 +100,8 @@ func newPublishingConnection(
 	logger logger,
 	marshaller Marshaller,
 ) *amqpConnection {
+	connectionName = fmt.Sprintf("%s-publisher-%s", connectionName, uuid.NewString())
+
 	conn := newConnection(ctx, uri, connectionName, keepAlive, retryDelay, logger, connectionTypePublisher, marshaller)
 
 	conn.maxRetry = maxRetry

--- a/connection_manager.go
+++ b/connection_manager.go
@@ -29,6 +29,10 @@ func newConnectionManager(
 	logger logger,
 	marshaller Marshaller,
 ) *connectionManager {
+	if connectionName == "" {
+		connectionName = libraryName
+	}
+
 	c := &connectionManager{
 		consumerConnection: newConsumerConnection(
 			ctx, uri, connectionName, keepAlive, retryDelay, logger, marshaller,

--- a/model.go
+++ b/model.go
@@ -121,10 +121,11 @@ func (m mqttPublishing) HashCode() string {
 }
 
 type RabbitMQEnvs struct {
-	Host     string `env:"RABBITMQ_HOST"`
-	Port     uint   `env:"RABBITMQ_PORT"`
-	Username string `env:"RABBITMQ_USERNAME"`
-	Password string `env:"RABBITMQ_PASSWORD"`
-	Vhost    string `env:"RABBITMQ_VHOST"`
-	UseTLS   bool   `env:"RABBITMQ_USE_TLS"`
+	Host           string `env:"RABBITMQ_HOST"`
+	Port           uint   `env:"RABBITMQ_PORT"`
+	Username       string `env:"RABBITMQ_USERNAME"`
+	Password       string `env:"RABBITMQ_PASSWORD"`
+	Vhost          string `env:"RABBITMQ_VHOST"`
+	UseTLS         bool   `env:"RABBITMQ_USE_TLS"`
+	ConnectionName string `env:"RABBITMQ_CONNECTION_NAME"`
 }


### PR DESCRIPTION
Fix a bug with the new `ConnectionName` parameter: We need to avoid duplication when spawning multiple connections with the same name. 

We also need to be able to set a connection name via environment variables when calling a client from env via `NewClientFromEnv` constructor.