### PR TITLE
Fix incomplete close mechanism in connectionManager

### DIFF
--- a/connection_manager.go
+++ b/connection_manager.go
@@ -49,11 +49,14 @@ func newConnectionManager(
 
 // close offers the basic connection and channel close() mechanism but with extra higher level checks.
 func (c *connectionManager) close() error {
-	if err := c.publisherConnection.close(); err != nil {
-		return err
+	errPublisher := c.publisherConnection.close()
+	errConsumer := c.consumerConnection.close()
+
+	if errPublisher != nil {
+		return errPublisher
 	}
 
-	return c.consumerConnection.close()
+	return errConsumer
 }
 
 // isReady returns true if both consumerConnection and publishingConnection are ready.


### PR DESCRIPTION
The `close()` method in `connectionManager` was returning early if the `publisherConnection.close()` failed, which prevented the `consumerConnection.close()` from being called. This could lead to resources not being properly released during shutdown. 

The fix ensures that both connections attempt to close, although it currently prioritizes returning the publisher error if one occurs. A more robust implementation might use a multi-error approach, but this fixes the immediate issue of masking the consumer closure call.

---

*This PR was generated by [PRJanitor](https://prjanitor.com) — an automated tool that finds and fixes small bugs in open-source projects.*

We respect your contribution guidelines — if your project doesn't accept bot PRs, we won't send more. You can also add a `.github/prjanitor.yml` file with `enabled: false` to opt out explicitly.